### PR TITLE
stackPushWord accidentally pushes whole word instead of low byte

### DIFF
--- a/py65emu/cpu.py
+++ b/py65emu/cpu.py
@@ -123,7 +123,7 @@ class CPU:
 
     def stackPushWord(self, v):
         self.stackPush(v >> 8)
-        self.stackPush(v)
+        self.stackPush(v & 0xff)
 
     def stackPop(self):
         v = self.mmu.read(self.stack_page*0x100 + ((self.r.s + 1) & 0xff))


### PR DESCRIPTION
stackPushWord used by JSR accidentally pushes the whole 16-bit instead of the low byte.

The supplied MMU sanitizes all writes with an & but it seems better to fix this upstream here.

Might also be worth documenting that all an MMU needs to implement are: reset, write, read, readWord. (readWord seems unnecessary for the interface, because it's only used once by the IRQ mechanism, and could easily be replaced by two reads. That's a tiny nitpick though.)