### PR TITLE
Fix mmu.py for python 3.10

### DIFF
--- a/py65emu/mmu.py
+++ b/py65emu/mmu.py
@@ -76,7 +76,7 @@ class MMU:
 
         elif value is not None:
             a = array.array('B')
-            a.fromstring(value.read())
+            a.frombytes(value.read())
             for i in range(len(a)):
                 newBlock['memory'][i+valueOffset] = a[i]
 


### PR DESCRIPTION
Change array.fromstring to array.frombytes for python 3.10. "make test" passes.
According to the documentation this should work on python 3.2+.