### PR TITLE
Duplicate BVC, elimination of dependence on math module

### DIFF
--- a/py65emu/cpu.py
+++ b/py65emu/cpu.py
@@ -276,7 +276,7 @@ class CPU:
             ("PL", 2, [0x10], ("N", False)),
             ("MI", 2, [0x30], ("N", True)),
             ("VC", 2, [0x50], ("V", False)),
-            ("VC", 2, [0x70], ("V", True)),
+            ("VS", 2, [0x70], ("V", True)),
             ("CC", 2, [0x90], ("C", False)),
             ("CS", 2, [0xb0], ("C", True)),
             ("NE", 2, [0xd0], ("Z", False)),

--- a/py65emu/cpu.py
+++ b/py65emu/cpu.py
@@ -785,27 +785,32 @@ class CPU:
                 self.r.p = self.r.p | 0b00100000
 
     def ROL(self, a):
+        # Allow v_new to spill into 9-bits and the Carry flag will be in bit 8
+        # (this was also done in ASL)
         if a == "a":
-            v_old = self.r.a
-            self.r.a = v_new = ((v_old << 1) + self.r.getFlag('C')) & 0xff
+            v_new = (v_old << 1) | self.r.getFlag('C')
+            self.r.a = v_new & 0xff
         else:
-            v_old = self.mmu.read(a)
-            v_new = ((v_old << 1) + self.r.getFlag('C')) & 0xff
-            self.mmu.write(a, v_new)
-
-        self.r.setFlag('C', v_old & 0x80)
-        self.r.ZN(v_new)
+            v_new = (self.mmu.read(a) << 1) | self.r.getFlag('C')
+            self.mmu.write(a, v_new & 0xff)
+        # Carry bit value is in bit 8:
+        self.r.setFlag('C', v_new & 0x100)
+        self.r.ZN(v_new & 0xff)
 
     def ROR(self, a):
+        # The existing Carry flag will shift into bit 7:
+        c_bit = self.r.getFlag('C') << 7
         if a == "a":
-            v_old = self.r.a
-            self.r.a = v_new = ((v_old >> 1) + self.r.getFlag('C')*0x80) & 0xff
+            # The new Carry flag comes from bit 0 of A:
+            self.r.setFlag('C', self.r.a & 0x01)
+            self.r.a = v_new = (c_bit | (self.r.a >> 1)) & 0xff
         else:
             v_old = self.mmu.read(a)
-            v_new = ((v_old >> 1) + self.r.getFlag('C')*0x80) & 0xff
+            # The new Carry flag comes from bit 0 of the operand:
+            self.r.setFlag('C', v_old & 0x01)
+            v_new = (c_bit | (v_old >> 1)) & 0xff
             self.mmu.write(a, v_new)
-
-        self.r.setFlag('C', v_old & 0x01)
+            
         self.r.ZN(v_new)
 
     def RTI(self, _):

--- a/py65emu/cpu.py
+++ b/py65emu/cpu.py
@@ -131,8 +131,8 @@ class CPU:
         return self.stackPop() + (self.stackPop() << 8)
 
     def fromBCD(self, v):
-        """The input integer v MUST be in the range [0,255] and is expected to be a binary-coded decimal value."""
-        return (v>>4) * 10 + (v & 0xf)
+        """The input integer v SHOULD be in the range [0,255] and is expected to be a binary-coded decimal value."""
+        return ((v & 0xf0)>>4) * 10 + (v & 0xf)
 
     def toBCD(self, v):
         """The input integer v MUST be in the range [0,99]."""

--- a/py65emu/cpu.py
+++ b/py65emu/cpu.py
@@ -139,7 +139,7 @@ class CPU:
         return ((v//10) << 4) | (v % 10)
 
     def fromTwosCom(self, v):
-        """The input integer v SHOULD be in the range [0,255].  Due to the use of 8-bit masks, any more-signficant bits in v will be discarded."""
+        """The input integer v SHOULD be in the range [0,255].  Due to the use of 8-bit masks, any more-significant bits in v will be discarded."""
         return (v & 0x7f) - (v & 0x80)
 
     interrupts = {

--- a/py65emu/cpu.py
+++ b/py65emu/cpu.py
@@ -31,13 +31,12 @@ class Registers:
         return bool(self.p & self.flagBit[flag])
 
     def setFlag(self, flag, v=True):
-        if v:
-            self.p = self.p | self.flagBit[flag]
-        else:
-            self.clearFlag(flag)
+        self.p = (self.p | self.flagBit[flag]) if v else (self.p & (0xFF ^ self.flagBit[flag]))
 
     def clearFlag(self, flag):
-        self.p = self.p & (255 - self.flagBit[flag])
+        # Python has a ones-complement operator but no way to indicate bit-width of its
+        # argument; an XOR with 0xFF does the same thing, though, in our 8-bit world:
+        self.p = self.p & (0xFF ^ self.flagBit[flag])
 
     def clearFlags(self):
         self.p = 0
@@ -133,10 +132,10 @@ class CPU:
         return self.stackPop() + (self.stackPop() << 8)
 
     def fromBCD(self, v):
-        return (((v & 0xf0) // 0x10) * 10) + (v & 0xf)
+        return (v>>4) * 10 + (v & 0xf)
 
     def toBCD(self, v):
-        return int(math.floor(v/10))*16 + (v % 10)
+        return ((v//10) << 4) | (v % 10)
 
     def fromTwosCom(self, v):
         return (v & 0x7f) - (v & 0x80)
@@ -169,7 +168,8 @@ class CPU:
     def ax_a(self):
         o = self.nextWord()
         a = o + self.r.x
-        if math.floor(o/0xff) != math.floor(a/0xff):
+        # Test for page cross:
+        if (o & 0xFF00) != (a & 0xFF00):
             self.cc += 1
 
         return a & 0xffff
@@ -177,7 +177,8 @@ class CPU:
     def ay_a(self):
         o = self.nextWord()
         a = o + self.r.y
-        if math.floor(o/0xff) != math.floor(a/0xff):
+        # Test for page cross:
+        if (o & 0xFF00) != (a & 0xFF00):
             self.cc += 1
 
         return a & 0xffff

--- a/py65emu/cpu.py
+++ b/py65emu/cpu.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import math
 import functools
-
 
 class Registers:
     """ An object to hold the CPU registers. """
@@ -31,12 +29,12 @@ class Registers:
         return bool(self.p & self.flagBit[flag])
 
     def setFlag(self, flag, v=True):
-        self.p = (self.p | self.flagBit[flag]) if v else (self.p & (0xFF ^ self.flagBit[flag]))
+        self.p = (self.p | self.flagBit[flag]) if v else (self.p & (0xff ^ self.flagBit[flag]))
 
     def clearFlag(self, flag):
         # Python has a ones-complement operator but no way to indicate bit-width of its
-        # argument; an XOR with 0xFF does the same thing, though, in our 8-bit world:
-        self.p = self.p & (0xFF ^ self.flagBit[flag])
+        # argument; an XOR with 0xff does the same thing, though, in our 8-bit world:
+        self.p = self.p & (0xff ^ self.flagBit[flag])
 
     def clearFlags(self):
         self.p = 0
@@ -120,6 +118,7 @@ class CPU:
         self.r.s = (self.r.s - 1) & 0xff
 
     def stackPushWord(self, v):
+        """The input integer v MUST be in the range [0,65535]."""
         self.stackPush(v >> 8)
         self.stackPush(v & 0xff)
 
@@ -132,12 +131,15 @@ class CPU:
         return self.stackPop() + (self.stackPop() << 8)
 
     def fromBCD(self, v):
+        """The input integer v MUST be in the range [0,255] and is expected to be a binary-coded decimal value."""
         return (v>>4) * 10 + (v & 0xf)
 
     def toBCD(self, v):
+        """The input integer v MUST be in the range [0,99]."""
         return ((v//10) << 4) | (v % 10)
 
     def fromTwosCom(self, v):
+        """The input integer v SHOULD be in the range [0,255].  Due to the use of 8-bit masks, any more-signficant bits in v will be discarded."""
         return (v & 0x7f) - (v & 0x80)
 
     interrupts = {
@@ -169,7 +171,7 @@ class CPU:
         o = self.nextWord()
         a = o + self.r.x
         # Test for page cross:
-        if (o & 0xFF00) != (a & 0xFF00):
+        if (o & 0xff00) != (a & 0xff00):
             self.cc += 1
 
         return a & 0xffff
@@ -178,7 +180,7 @@ class CPU:
         o = self.nextWord()
         a = o + self.r.y
         # Test for page cross:
-        if (o & 0xFF00) != (a & 0xFF00):
+        if (o & 0xff00) != (a & 0xff00):
             self.cc += 1
 
         return a & 0xffff
@@ -204,7 +206,8 @@ class CPU:
         o = (self.mmu.read((i + 1) & 0xff) << 8) + self.mmu.read(i)
         a = o + self.r.y
 
-        if math.floor(o/0xff) != math.floor(a/0xff):
+        # Test for page cross:
+        if (o & 0xff00) != (a & 0xff00):
             self.cc += 1
 
         return a & 0xffff
@@ -660,10 +663,8 @@ class CPU:
         if self.r.getFlag(v[0]) is v[1]:
             o = self.r.pc
             self.r.pc += self.fromTwosCom(d)
-            if math.floor(o/0xff) == math.floor(self.r.pc/0xff):
-                self.cc += 1
-            else:
-                self.cc += 2
+            # Page cross adds an additional cycle:
+            self.cc += 1 + (1 if ((o & 0xff00) != (self.r.pc & 0xff00)) else 0)
 
     def BRK(self, _):
         self.r.setFlag('B')


### PR DESCRIPTION
Love the project, good work with those illegal opcodes!  I got here via a page someone did dissecting the tilemap building code in the NES Super Mario Bros. and py65emu was used to run the subroutines from the NES cart dump.

1. In the `_ops` array the BVC opcode was repeated for BVS (0x70).
2. The use of `math.floor()` in determining page-crossings can be accomplished with bitwise-AND of the addresses then comparison; no need for the math module at all.
3. Some instances of addition/subtraction and multiplication to do bit manipulation were replaced with bitwise operations (e.g. set/reset flag bits, insert Carry bit into ROL/ROR).